### PR TITLE
Adding Django3.1 Support

### DIFF
--- a/django_reactive/fields.py
+++ b/django_reactive/fields.py
@@ -1,13 +1,26 @@
-from django.contrib.postgres.fields import JSONField as BaseJSONField
 from django.core.exceptions import ValidationError
 from jsonschema import validate, ValidationError as JSONSchemaValidationError
 
 from .widget.fields import ReactJSONSchemaFormField
 from .widget.widgets import ReactJSONSchemaFormWidget
 
+try:
+    # DJANGO 3.1
+    from django.db.models import JSONField as BaseJSONField
+except ImportError:
+    from django.contrib.postgres.fields import JSONField as BaseJSONField
+
 
 class ReactJSONSchemaField(BaseJSONField):
-    def __init__(self, schema=None, ui_schema=None, on_render=None, extra_css=None, extra_js=None, **kwargs):
+    def __init__(
+        self,
+        schema=None,
+        ui_schema=None,
+        on_render=None,
+        extra_css=None,
+        extra_js=None,
+        **kwargs
+    ):
         kwargs.setdefault("default", dict)
         super(ReactJSONSchemaField, self).__init__(**kwargs)
         self.schema = schema

--- a/django_reactive/widget/__init__.py
+++ b/django_reactive/widget/__init__.py
@@ -1,6 +1,6 @@
 from django.forms import ModelForm
 
-from .fields import ReactJSONSchemaFormField
+from django_reactive.widget.fields import ReactJSONSchemaFormField
 
 
 class ReactJSONSchemaModelForm(ModelForm):
@@ -12,5 +12,5 @@ class ReactJSONSchemaModelForm(ModelForm):
         on_render_object = kwargs.get("instance", None)
         super().__init__(*args, **kwargs)
         for field_name, field_value in self.fields.items():
-            if isinstance(field_value, django_reactive.forms.fields.ReactJSONSchemaFormField):
+            if isinstance(field_value, ReactJSONSchemaFormField):
                 self.fields[field_name].widget.on_render_object = on_render_object

--- a/django_reactive/widget/fields.py
+++ b/django_reactive/widget/fields.py
@@ -1,6 +1,10 @@
-from django.contrib.postgres.forms.jsonb import JSONField
-
 from .widgets import ReactJSONSchemaFormWidget
+
+try:
+    # DJANGO 3.1
+    from django.forms import JSONField
+except ImportError:
+    from django.contrib.postgres.forms.jsonb import JSONField
 
 
 class ReactJSONSchemaFormField(JSONField):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = True
 envlist =
-    {py37,py38}-django-22
+    {py37, py38}-{django-22,django-31}
 
 [testenv]
 setenv =


### PR DESCRIPTION
1. Added Django3.1 Support
2. `JSONField` is moved to models from contrib.postgres. This is changed for models and forms.
3. tox updated to support Django 3.1